### PR TITLE
Make AsyncButtonOptions Sendable for Swift 6 compatibility

### DIFF
--- a/Sources/AsyncButton/AsyncButtonOptions.swift
+++ b/Sources/AsyncButton/AsyncButtonOptions.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct AsyncButtonOptions: OptionSet {
+public struct AsyncButtonOptions: OptionSet, Sendable {
     
     public let rawValue: Int
     


### PR DESCRIPTION
Simply letting `AsyncButtonOptions` conform to `Sendable` allows the package to be compiled with Swift 6.